### PR TITLE
Update IAO_0000027 in omo-edit.owl

### DIFF
--- a/src/ontology/omo-edit.owl
+++ b/src/ontology/omo-edit.owl
@@ -1024,8 +1024,8 @@ EquivalentTo: xsd:integer[&gt; 2151 , &lt;= 2300]
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000027">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
-        <obo:IAO_0000111 xml:lang="en">data item</obo:IAO_0000111>
-        <rdfs:label xml:lang="en">data item</rdfs:label>
+        <obo:IAO_0000111 xml:lang="en">data entity</obo:IAO_0000111>
+        <rdfs:label xml:lang="en">data entity</rdfs:label>
     </owl:Class>
     
 


### PR DESCRIPTION
Updates the label of IAO:0000027 from 'data item' to 'data entity' in line with [this PR](https://github.com/information-artifact-ontology/IAO/pull/289) so that the OMO label no longer conflicts with IAO's updated label (see also [the failing check in this PR](https://github.com/information-artifact-ontology/IAO/pull/300)).